### PR TITLE
Add input actions for torque converter tuner

### DIFF
--- a/lua/common/input_actions.json
+++ b/lua/common/input_actions.json
@@ -1,0 +1,10 @@
+{
+  "conv_incDiam":  {"title": "Increase Converter Diameter",  "category": "Converter Tuner"},
+  "conv_decDiam":  {"title": "Decrease Converter Diameter",  "category": "Converter Tuner"},
+  "conv_incStiff": {"title": "Increase Converter Stiffness", "category": "Converter Tuner"},
+  "conv_decStiff": {"title": "Decrease Converter Stiffness", "category": "Converter Tuner"},
+  "conv_incCoupl": {"title": "Increase Coupling AV Ratio",  "category": "Converter Tuner"},
+  "conv_decCoupl": {"title": "Decrease Coupling AV Ratio",  "category": "Converter Tuner"},
+  "conv_incStall": {"title": "Increase Stall Torque Ratio",  "category": "Converter Tuner"},
+  "conv_decStall": {"title": "Decrease Stall Torque Ratio",  "category": "Converter Tuner"}
+}


### PR DESCRIPTION
## Summary
- add `lua/common/input_actions.json` so BeamNG shows controls for the torque converter tuner

## Testing
- `npm test` *(fails: no `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68513420061c83239a728f49d7eb0d43