### PR TITLE
Load converter tuner extension at startup

### DIFF
--- a/lua/ge/extensions/converter_tuner_ext.lua
+++ b/lua/ge/extensions/converter_tuner_ext.lua
@@ -5,7 +5,8 @@ local M = {}
   любому автомобилю, где в powertrain присутствует гидротрансформатор.
 --]]
 
-M.id = "converterTunerExtension"
+-- идентификатор модуля совпадает с именем файла
+M.id = "converter_tuner_ext"
 
 -- добавляет контроллер к указанному автомобилю
 local function addController(veh)


### PR DESCRIPTION
## Summary
- relocate `converter_tuner_ext.lua` to a global extensions folder
- align module ID with filename so BeamNG loads the extension automatically

## Testing
- `lua` script simulating vehicle spawn shows the controller command is queued

------
https://chatgpt.com/codex/tasks/task_e_68513416eda883238a73f9a562f2f1bd