### PR TITLE
Fix info.json key casing

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,9 +1,9 @@
 {
-  "Name": "Universal Torque-Converter Tuner",
-  "Author": "Bethelss",
-  "Version": "0.1",
-  "Description": "Позволяет настраивать диаметр, жесткость и другие параметры гидротрансформатора на любом автомобиле.",
-  "Dependencies": [],
-  "Repository": "",
-  "Contact": ""
+  "name": "Universal Torque-Converter Tuner",
+  "author": "Bethelss",
+  "version": "0.1",
+  "description": "Позволяет настраивать диаметр, жесткость и другие параметры гидротрансформатора на любом автомобиле.",
+  "dependencies": [],
+  "repository": "",
+  "contact": ""
 }


### PR DESCRIPTION
## Summary
- lowercase keys in `info.json` to follow naming conventions

## Testing
- `find lua -name '*.lua' -print -exec luac -p {} \;` *(fails: `luac` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6851340a753c8323806944041251a54f